### PR TITLE
now redirecting to user's profile page on logging in

### DIFF
--- a/app/controllers/UsersController.php
+++ b/app/controllers/UsersController.php
@@ -98,7 +98,7 @@ class UsersController extends Controller
         $input = Input::all();
 
         if ($repo->login($input)) {
-            return Redirect::intended('/');
+            return Redirect::action('UsersController@showProfile', Confide::user()->id);
         } else {
             if ($repo->isThrottled($input)) {
                 $err_msg = Lang::get('confide::confide.alerts.too_many_attempts');


### PR DESCRIPTION
the reason the redirect::intended was not working is because we were'nt
intending to go anywhere, we followed a link from the footer to the log in page,
the redirect would work if we tried to go to some auth-locked content and got
thrown on the log in page
